### PR TITLE
Display snippet compilation messages in scaladoc

### DIFF
--- a/scaladoc-js/resources/scaladoc-searchbar.css
+++ b/scaladoc-js/resources/scaladoc-searchbar.css
@@ -105,27 +105,33 @@
 
 .snippet-comment-button {
     position: absolute;
+    display: inline-block;
     left: 50%;
     width: 24px;
     height: 24px;
+    background:
+        linear-gradient(#fff, #fff),
+        linear-gradient(#fff, #fff),
+        #aaa;
+    background-position: center;
+    background-size: 50% 2px, 2px 50%;
+    background-repeat: no-repeat;
+    border-radius: 12px;
+    box-shadow: 0 0 2px black;
 }
 
-.show-snippet-comments-button {
-    -ms-transform: translate(calc(-50% + 5em), -50%);
-    transform: translate(calc(-50% + 5em), -50%);
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Ccircle cx='12' cy='12' r='12' fill='white'/%3E %3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M19 11.0053L19 13.1085H12.9873L12.988 19H10.8714L10.8721 13.1085L5 13.1085L5 11.0053L10.8721 11.0053V5L12.9865 5.00074L12.988 11.0045L19 11.0053Z' fill='%2327282C' fill-opacity='0.75'/%3E %3C/svg%3E");
-}
-
-.show-snippet-comments-button:hover {
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Ccircle cx='12' cy='12' r='12' fill='light grey'/%3E %3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M19 11.0053L19 13.1085H12.9873L12.988 19H10.8714L10.8721 13.1085L5 13.1085L5 11.0053L10.8721 11.0053V5L12.9865 5.00074L12.988 11.0045L19 11.0053Z' fill='%2327282C' fill-opacity='0.75'/%3E %3C/svg%3E");
+.snippet-comment-button:hover {
+    background:
+        linear-gradient(#444, #444),
+        linear-gradient(#444, #444),
+        #ddd;
+    background-position: center;
+    background-size: 50% 2px, 2px 50%;
+    background-repeat: no-repeat;
 }
 
 .hide-snippet-comments-button {
-    -ms-transform: translate(calc(-50% + 5em), -50%) rotate(45deg);
-    transform: translate(calc(-50% + 5em), -50%) rotate(45deg);
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Ccircle cx='12' cy='12' r='12' fill='white'/%3E %3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M19 11.0053L19 13.1085H12.9873L12.988 19H10.8714L10.8721 13.1085L5 13.1085L5 11.0053L10.8721 11.0053V5L12.9865 5.00074L12.988 11.0045L19 11.0053Z' fill='%2327282C' fill-opacity='0.75'/%3E %3C/svg%3E");
+    -ms-transform: rotate(45deg);
+    transform: rotate(45deg);
 }
 
-.hide-snippet-comments-button:hover {
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Ccircle cx='12' cy='12' r='12' fill='light grey'/%3E %3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M19 11.0053L19 13.1085H12.9873L12.988 19H10.8714L10.8721 13.1085L5 13.1085L5 11.0053L10.8721 11.0053V5L12.9865 5.00074L12.988 11.0045L19 11.0053Z' fill='%2327282C' fill-opacity='0.75'/%3E %3C/svg%3E");
-}

--- a/scaladoc-js/src/searchbar/code-snippets/CodeSnippets.scala
+++ b/scaladoc-js/src/searchbar/code-snippets/CodeSnippets.scala
@@ -4,19 +4,6 @@ import org.scalajs.dom._
 import org.scalajs.dom.ext._
 
 class CodeSnippets:
-  val replacePatternsAndResults: Seq[(String, String)] = Seq(
-    """(\/\/{{\n)((.|\n)*?)(\/\/}}\n)""" -> """<span class="hideable">$2</span>""", // wrap content of block directives
-    """(\/\/.*?)(\n|\$)""" -> """<span class="hideable">$1</span>$2""", // wrap single line comment
-    """(\/\*)((.|\n)*?)(\*\/)""" -> """<span class="hideable">$0</span>""", // wrap multi line comment
-  )
-
-  document.querySelectorAll("code").foreach {
-    case e: html.Element => e.innerHTML = replacePatternsAndResults.foldLeft(e.innerHTML) {
-      case (acc, (pattern, result)) =>
-        acc.replaceAll(pattern, result)
-    }
-  }
-
   def toggleHide(e: html.Element | html.Document) = e.querySelectorAll("code span.hideable").foreach {
     case e: html.Element if e.style.getPropertyValue("display").isEmpty => e.style.setProperty("display", "none")
     case e: html.Element => e.style.removeProperty("display")
@@ -29,15 +16,12 @@ class CodeSnippets:
       val a = document.createElement("a")
       a.addEventListener("click", { (_: MouseEvent) =>
         if(a.classList.contains("hide-snippet-comments-button")) {
-          a.classList.add("show-snippet-comments-button")
           a.classList.remove("hide-snippet-comments-button")
         } else {
           a.classList.add("hide-snippet-comments-button")
-          a.classList.remove("show-snippet-comments-button")
         }
         toggleHide(e)
       })
       a.classList.add("snippet-comment-button")
-      a.classList.add("show-snippet-comments-button")
       e.insertBefore(a, e.firstChild)
   }

--- a/scaladoc-testcases/src/tests/snippetCompilerTest.scala
+++ b/scaladoc-testcases/src/tests/snippetCompilerTest.scala
@@ -2,9 +2,29 @@ package snippetCompiler
 
 /**
   * ```scala sc:compile
+  * //{
+  * import scala.collection.Seq
+  * //}
+  *
   * def a = 2
   * val x = 1 + List()
   * a
+  *
+  * try {
+  *   2+3
+  * }
+  *
+  * /*
+  *   Huge comment
+  * */
+  * val xd: String = 42
+  *
+  * def a(i: Int): Boolean = i match // This is a function
+  *   case 1 => true
+  *
+  * val b: Int = 2.3 /* Also quite a big comment */
+  *
+  * val d: Long = "asd"
   * ```
   *
   * ```scala sc:failing
@@ -23,3 +43,11 @@ package snippetCompiler
   * ```
   */
 class A { }
+
+/**
+ *
+ * ```scala sc:compile
+ * val c: Int = 4.5
+ * ```
+ */
+class B { }

--- a/scaladoc/resources/dotty_res/styles/scalastyle.css
+++ b/scaladoc/resources/dotty_res/styles/scalastyle.css
@@ -93,17 +93,52 @@ code {
   padding: 0 .3em;
 }
 pre {
-  overflow-x: auto;
   scrollbar-width: thin;
+  margin: 0px;
 }
 pre code, pre code.hljs {
   font-size: 1em;
   padding: 0;
 }
-pre, .symbol.monospace {
+.snippet {
   padding: 12px 8px 10px 12px;
+  background: var(--code-bg);
+  margin: 1em 0px;
+  border-radius: 2px;
+  box-shadow: 0 0 2px #888;
+}
+.snippet-error {
+  border-bottom: 2px dotted red;
+}
+.snippet-warn {
+  border-bottom: 2px dotted orange;
+}
+.snippet-info {
+  border-bottom: 2px dotted teal;
+}
+.snippet-debug {
+  border-bottom: 2px dotted pink;
+}
+.tooltip {
+  position: relative;
+}
+.tooltip:hover:after {
+  content: attr(label);
+  padding: 4px 8px;
+  color: white;
+  background-color:black;
+  position: absolute;
+  left: 0;
+  z-index:10;
+  box-shadow:0 0 3px #444;
+  opacity: 0.8;
+}
+pre, .symbol.monospace {
   font-weight: 500;
   font-size: 12px;
+}
+.symbol.monospace {
+  padding: 12px 8px 10px 12px;
 }
 a, a:visited, span[data-unresolved-link] {
   text-decoration: none;

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilationResult.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilationResult.scala
@@ -3,9 +3,13 @@ package snippets
 
 import dotty.tools.io.{ AbstractFile }
 
-case class Position(line: Int, column: Int, sourceLine: String)
+case class Position(line: Int, column: Int, sourceLine: String, relativeLine: Int)
 
-case class SnippetCompilerMessage(position: Option[Position], message: String, level: MessageLevel)
+case class SnippetCompilerMessage(position: Option[Position], message: String, level: MessageLevel):
+  def getSummary: String =
+    position.fold(s"${level.text}: ${message}") { pos =>
+      s"At ${pos.line}:${pos.column}:\n${pos.sourceLine}${level.text}: ${message}"
+    }
 
 case class SnippetCompilationResult(
   wrappedSnippet: String,
@@ -13,15 +17,7 @@ case class SnippetCompilationResult(
   result: Option[AbstractFile],
   messages: Seq[SnippetCompilerMessage]
 ):
-  def getSummary: String =
-    messages.map(m =>
-      m.position.fold(
-        s"${m.level.text}: ${m.message}"
-      )(pos =>
-        s"At ${pos.line}:${pos.column}:\n${pos.sourceLine}${m.level.text}: ${m.message}"
-      )
-    ).mkString("\n")
-
+  def getSummary: String = messages.map(_.getSummary).mkString("\n")
 
 enum MessageLevel(val text: String):
   case Info extends MessageLevel("Info")

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
@@ -48,7 +48,7 @@ class SnippetCompiler(
       case diagnostic if diagnostic.position.isPresent =>
         val diagPos = diagnostic.position.get
         val pos = Some(
-          Position(diagPos.line + line, diagPos.column + column, diagPos.lineContent)
+          Position(diagPos.line + line, diagPos.column + column, diagPos.lineContent, diagPos.line)
         )
         val msg = nullableMessage(diagnostic.message)
         val level = MessageLevel.fromOrdinal(diagnostic.level)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -10,6 +10,7 @@ import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.options.MutableDataSet
 
 import scala.quoted._
+import dotty.tools.scaladoc.tasty.comments.markdown.ExtendedFencedCodeBlock
 import dotty.tools.scaladoc.tasty.comments.wiki.Paragraph
 import dotty.tools.scaladoc.DocPart
 import dotty.tools.scaladoc.tasty.SymOps
@@ -182,15 +183,13 @@ abstract class MarkupConversion[T](val repr: Repr, snippetChecker: SnippetChecke
       (str: String, lineOffset: SnippetChecker.LineOffset, argOverride: Option[SCFlags]) => {
           val arg = argOverride.fold(pathBasedArg)(pathBasedArg.overrideFlag(_))
 
-          val res = snippetChecker.checkSnippet(str, Some(data), arg, lineOffset)
-          snippetChecker.checkSnippet(str, Some(data), arg, lineOffset).foreach { _ match {
+          snippetChecker.checkSnippet(str, Some(data), arg, lineOffset).collect {
               case r: SnippetCompilationResult if !r.isSuccessful =>
                 val msg = s"In member ${s.name} (${s.dri.location}):\n${r.getSummary}"
                 report.error(msg)(using dctx.compilerContext)
-              case _ =>
-            }
+                r
+              case r => r
           }
-          res
       }
     }
 
@@ -252,29 +251,44 @@ class MarkdownCommentParser(repr: Repr, snippetChecker: SnippetChecker)(using dc
     val nodes = root.getDescendants().asScala.collect {
       case fcb: mda.FencedCodeBlock => fcb
     }.toList
-    if !nodes.isEmpty then {
-      val checkingFunc: SnippetChecker.SnippetCheckingFunc = snippetCheckingFunc(owner)
-      nodes.foreach { node =>
-        val snippet = node.getContentChars.toString
-        val lineOffset = node.getStartLineNumber
-        val info = node.getInfo.toString
-        val argOverride =
-          info.split(" ")
-            .find(_.startsWith("sc:"))
-            .map(_.stripPrefix("sc:"))
-            .map(snippets.SCFlagsParser.parse)
-            .flatMap(_.toOption)
-        checkingFunc(snippet, lineOffset, argOverride) match {
-          case Some(SnippetCompilationResult(wrapped, _, _, _)) if dctx.snippetCompilerArgs.debug =>
-            val s = sequence.BasedSequence.EmptyBasedSequence()
-              .append(wrapped)
-              .append(sequence.BasedSequence.EOL)
-            val content = mdu.BlockContent()
-            content.add(s, 0)
-            node.setContent(content)
-          case _ =>
-        }
+    val checkingFunc: SnippetChecker.SnippetCheckingFunc = snippetCheckingFunc(owner)
+    nodes.foreach { node =>
+      val snippet = node.getContentChars.toString
+      val lineOffset = node.getStartLineNumber
+      val info = node.getInfo.toString
+      val argOverride =
+        info.split(" ")
+          .find(_.startsWith("sc:"))
+          .map(_.stripPrefix("sc:"))
+          .map(snippets.SCFlagsParser.parse)
+          .flatMap(_.toOption)
+      val snippetCompilationResult = checkingFunc(snippet, lineOffset, argOverride) match {
+        case result@Some(SnippetCompilationResult(wrapped, _, _, _)) if dctx.snippetCompilerArgs.debug =>
+          val s = sequence.BasedSequence.EmptyBasedSequence()
+            .append(wrapped)
+            .append(sequence.BasedSequence.EOL)
+          val content = mdu.BlockContent()
+          content.add(s, 0)
+          node.setContent(content)
+          result
+        case result =>
+          // result.modify(_.each.messages.each.position.each.relativeLine).using(_ - 2)
+          result.map { r =>
+            r.copy(
+              messages = r.messages.map { m =>
+                m.copy(
+                  position = m.position.map { p =>
+                    p.copy(
+                      relativeLine = p.relativeLine - 2
+                    )
+                  }
+                )
+              }
+            )
+          }
       }
+      node.insertBefore(new ExtendedFencedCodeBlock(node, snippetCompilationResult))
+      node.unlink()
     }
     root
   }

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -251,44 +251,45 @@ class MarkdownCommentParser(repr: Repr, snippetChecker: SnippetChecker)(using dc
     val nodes = root.getDescendants().asScala.collect {
       case fcb: mda.FencedCodeBlock => fcb
     }.toList
-    val checkingFunc: SnippetChecker.SnippetCheckingFunc = snippetCheckingFunc(owner)
-    nodes.foreach { node =>
-      val snippet = node.getContentChars.toString
-      val lineOffset = node.getStartLineNumber
-      val info = node.getInfo.toString
-      val argOverride =
-        info.split(" ")
-          .find(_.startsWith("sc:"))
-          .map(_.stripPrefix("sc:"))
-          .map(snippets.SCFlagsParser.parse)
-          .flatMap(_.toOption)
-      val snippetCompilationResult = checkingFunc(snippet, lineOffset, argOverride) match {
-        case result@Some(SnippetCompilationResult(wrapped, _, _, _)) if dctx.snippetCompilerArgs.debug =>
-          val s = sequence.BasedSequence.EmptyBasedSequence()
-            .append(wrapped)
-            .append(sequence.BasedSequence.EOL)
-          val content = mdu.BlockContent()
-          content.add(s, 0)
-          node.setContent(content)
-          result
-        case result =>
-          // result.modify(_.each.messages.each.position.each.relativeLine).using(_ - 2)
-          result.map { r =>
-            r.copy(
-              messages = r.messages.map { m =>
-                m.copy(
-                  position = m.position.map { p =>
-                    p.copy(
-                      relativeLine = p.relativeLine - 2
-                    )
-                  }
-                )
-              }
-            )
-          }
+    if nodes.nonEmpty then {
+      val checkingFunc: SnippetChecker.SnippetCheckingFunc = snippetCheckingFunc(owner)
+      nodes.foreach { node =>
+        val snippet = node.getContentChars.toString
+        val lineOffset = node.getStartLineNumber
+        val info = node.getInfo.toString
+        val argOverride =
+          info.split(" ")
+            .find(_.startsWith("sc:"))
+            .map(_.stripPrefix("sc:"))
+            .map(snippets.SCFlagsParser.parse)
+            .flatMap(_.toOption)
+        val snippetCompilationResult = checkingFunc(snippet, lineOffset, argOverride) match {
+          case result@Some(SnippetCompilationResult(wrapped, _, _, _)) if dctx.snippetCompilerArgs.debug =>
+            val s = sequence.BasedSequence.EmptyBasedSequence()
+              .append(wrapped)
+              .append(sequence.BasedSequence.EOL)
+            val content = mdu.BlockContent()
+            content.add(s, 0)
+            node.setContent(content)
+            result
+          case result =>
+            result.map { r =>
+              r.copy(
+                messages = r.messages.map { m =>
+                  m.copy(
+                    position = m.position.map { p =>
+                      p.copy(
+                        relativeLine = p.relativeLine - lineOffset
+                      )
+                    }
+                  )
+                }
+              )
+            }
+        }
+        node.insertBefore(new ExtendedFencedCodeBlock(node, snippetCompilationResult))
+        node.unlink()
       }
-      node.insertBefore(new ExtendedFencedCodeBlock(node, snippetCompilationResult))
-      node.unlink()
     }
     root
   }

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderer.scala
@@ -6,10 +6,7 @@ import dotty.tools.scaladoc.snippets._
 
 case class SnippetLine(content: String, lineNo: Int, classes: Set[String] = Set.empty, messages: Seq[String] = Seq.empty):
   def withClass(cls: String) = this.copy(classes = classes + cls)
-  private def escapeQuotes(msg: String): String = msg.flatMap {
-    case '"' => "&quot;"
-    case c => c.toString
-  }
+  private def escapeQuotes(msg: String): String = msg.replace("\"", "&quot;")
   def toHTML =
     val label = if messages.nonEmpty then s"""label="${messages.map(escapeQuotes).mkString("\n")}"""" else ""
     s"""<span id="$lineNo" class="${classes.mkString(" ")}" $label>$content</span>"""

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderer.scala
@@ -1,0 +1,130 @@
+package dotty.tools.scaladoc.tasty.comments.markdown
+
+import com.vladsch.flexmark.html._
+
+import dotty.tools.scaladoc.snippets._
+
+case class SnippetLine(content: String, lineNo: Int, classes: Set[String] = Set.empty, messages: Seq[String] = Seq.empty):
+  def withClass(cls: String) = this.copy(classes = classes + cls)
+  private def escapeQuotes(msg: String): String = msg.flatMap {
+    case '"' => "&quot;"
+    case c => c.toString
+  }
+  def toHTML =
+    val label = if messages.nonEmpty then s"""label="${messages.map(escapeQuotes).mkString("\n")}"""" else ""
+    s"""<span id="$lineNo" class="${classes.mkString(" ")}" $label>$content</span>"""
+
+object SnippetRenderer:
+  private def compileMessageCSSClass(msg: SnippetCompilerMessage) = msg.level match
+    case MessageLevel.Info => "snippet-info"
+    case MessageLevel.Warning => "snippet-warn"
+    case MessageLevel.Error => "snippet-error"
+    case MessageLevel.Debug => "snippet-debug"
+
+  private def cutBetwenSymbols[A](
+    startSymbol: String,
+    endSymbol: String,
+    snippetLines: Seq[SnippetLine]
+  )(
+    f: (Seq[SnippetLine], Seq[SnippetLine], Seq[SnippetLine]) => A
+  ): Option[A] =
+    for {
+      startIdx <- snippetLines.zipWithIndex.find(_._1.content.contains(startSymbol)).map(_._2)
+      endIdx <- snippetLines.zipWithIndex.find(_._1.content.contains(endSymbol)).map(_._2)
+      (tmp, end) = snippetLines.splitAt(endIdx+1)
+      (begin, mid) = tmp.splitAt(startIdx)
+    } yield f(begin, mid, end)
+
+  private def wrapHiddenSymbols(snippetLines: Seq[SnippetLine]): Seq[SnippetLine] =
+    val mRes = cutBetwenSymbols("//{", "//}", snippetLines) {
+      case (begin, mid, end) =>
+        begin ++ mid.drop(1).dropRight(1).map(_.withClass("hideable")) ++ wrapHiddenSymbols(end)
+    }
+    mRes.getOrElse(snippetLines)
+
+  private def wrapLineInBetween(startSymbol: Option[String], endSymbol: Option[String], line: SnippetLine): SnippetLine =
+    val startIdx = startSymbol.map(s => line.content.indexOf(s))
+    val endIdx = endSymbol.map(s => line.content.indexOf(s))
+    (startIdx, endIdx) match
+      case (Some(idx), None) =>
+        val (code, comment) = line.content.splitAt(idx)
+        comment match
+          case _ if code.forall(_.isWhitespace) =>
+            line.withClass("hideable")
+          case _ if comment.last == '\n' =>
+            line.copy(content = code + s"""<span class="hideable">${comment.dropRight(1)}</span>${"\n"}""")
+          case _  =>
+            line.copy(content = code + s"""<span class="hideable">$comment</span>""")
+      case (None, Some(idx)) =>
+        val (comment, code) = line.content.splitAt(idx+endSymbol.get.size)
+        comment match
+          case _ if code.forall(_.isWhitespace) =>
+            line.withClass("hideable")
+          case _ =>
+            line.copy(content = s"""<span class="hideable">$comment</span>""" + code)
+      case (Some(startIdx), Some(endIdx)) =>
+        val (tmp, end) = line.content.splitAt(endIdx+endSymbol.get.size)
+        val (begin, comment) = tmp.splitAt(startIdx)
+        line.copy(content = begin + s"""<span class="hideable">$comment</span>""" + end)
+      case _ => line
+
+  private def wrapSingleLineComments(snippetLines: Seq[SnippetLine]): Seq[SnippetLine] =
+    snippetLines.map { line =>
+      line.content.indexOf("//") match
+        case -1 => line
+        case idx =>
+          wrapLineInBetween(Some("//"), None, line)
+    }
+
+  private def wrapMultiLineComments(snippetLines: Seq[SnippetLine]): Seq[SnippetLine] =
+    val mRes = cutBetwenSymbols("/*", "*/", snippetLines) {
+      case (begin, mid, end) if mid.size == 1 =>
+        val midRedacted = mid.map(wrapLineInBetween(Some("/*"), Some("*/"), _))
+        begin ++ midRedacted ++ end
+      case (begin, mid, end) =>
+        val midRedacted =
+          mid.take(1).map(wrapLineInBetween(Some("/*"), None, _))
+            ++ mid.drop(1).dropRight(1).map(_.withClass("hideable"))
+            ++ mid.takeRight(1).map(wrapLineInBetween(None, Some("*/"), _))
+        begin ++ midRedacted ++ wrapMultiLineComments(end)
+    }
+    mRes.getOrElse(snippetLines)
+
+  private def wrapCodeLines(codeLines: Seq[String]): Seq[SnippetLine] =
+    val snippetLines = codeLines.zipWithIndex.map {
+      case (content, idx) => SnippetLine(content, idx)
+    }
+    wrapHiddenSymbols
+      .andThen(wrapSingleLineComments)
+      .andThen(wrapMultiLineComments)
+      .apply(snippetLines)
+
+  private def addCompileMessages(messages: Seq[SnippetCompilerMessage])(codeLines: Seq[SnippetLine]): Seq[SnippetLine] = //TODO add tooltips and stuff
+    val messagesDict = messages.filter(_.position.nonEmpty).groupBy(_.position.get.relativeLine).toMap[Int, Seq[SnippetCompilerMessage]]
+    codeLines.map { line =>
+      messagesDict.get(line.lineNo) match
+        case None => line
+        case Some(messages) =>
+          val classes = List(
+            messages.find(_.level == MessageLevel.Error).map(compileMessageCSSClass),
+            messages.find(_.level == MessageLevel.Warning).map(compileMessageCSSClass),
+            messages.find(_.level == MessageLevel.Info).map(compileMessageCSSClass)
+          ).flatten
+          line.copy(classes = line.classes ++ classes.toSet ++ Set("tooltip"), messages = messages.map(_.message))
+    }
+
+  private def messagesHTML(messages: Seq[SnippetCompilerMessage]): String =
+    if messages.isEmpty
+      then ""
+      else
+        val content = messages
+          .map { msg =>
+            s"""<span class="${compileMessageCSSClass(msg)}">${msg.getSummary}</span>"""
+          }
+          .mkString("<br>")
+        s"""<hr>$content"""
+
+  def renderSnippetWithMessages(codeLines: Seq[String], messages: Seq[SnippetCompilerMessage]): String =
+    val transformedLines = wrapCodeLines.andThen(addCompileMessages(messages)).apply(codeLines).map(_.toHTML)
+    val codeHTML = s"""<code class="language-scala">${transformedLines.mkString("")}<pre></pre></code>"""
+    s"""<div class="snippet"><pre>$codeHTML</pre></div>"""


### PR DESCRIPTION
Preview:
![Peek 2021-03-30 18-26](https://user-images.githubusercontent.com/39772805/113023168-a9c6fb80-9185-11eb-91e1-894b05fa714c.gif)
![Peek 2021-03-30 18-21](https://user-images.githubusercontent.com/39772805/113023176-aaf82880-9185-11eb-9a16-a1671be7a4ba.gif)

BTW one is with orange warnings the other is with yellow. I'm more of a fan of orange, but dunno. WDYT?